### PR TITLE
Add keyboard selection, Caps Lock → Backspace remap, and permission detection

### DIFF
--- a/Sources/HRM/App/AccessibilityManager.swift
+++ b/Sources/HRM/App/AccessibilityManager.swift
@@ -1,4 +1,5 @@
 import ApplicationServices
+import CoreGraphics
 import Foundation
 
 enum AccessibilityManager {
@@ -6,27 +7,53 @@ enum AccessibilityManager {
         AXIsProcessTrusted()
     }
 
-    static func requestPermission() {
+    static var isInputMonitoringGranted: Bool {
+        CGPreflightListenEventAccess()
+    }
+
+    static var hasAllPermissions: Bool {
+        isTrusted && isInputMonitoringGranted
+    }
+
+    static func requestAccessibility() {
         let options = [kAXTrustedCheckOptionPrompt.takeRetainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
     }
 
-    static func ensureAccessibility(completion: @escaping (Bool) -> Void) {
-        if isTrusted {
+    static func requestInputMonitoring() {
+        CGRequestListenEventAccess()
+    }
+
+    static func ensureAllPermissions(completion: @escaping (Bool) -> Void) {
+        if hasAllPermissions {
             completion(true)
             return
         }
 
-        requestPermission()
+        // Request Accessibility first if needed
+        if !isTrusted {
+            requestAccessibility()
+        }
 
-        // Poll for permission grant
+        // Poll for both permissions
         var attempts = 0
+        var didRequestInputMonitoring = false
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
             attempts += 1
-            if AXIsProcessTrusted() {
+
+            let axGranted = AXIsProcessTrusted()
+            let imGranted = CGPreflightListenEventAccess()
+
+            // Once Accessibility is granted, request Input Monitoring once if still needed
+            if axGranted && !imGranted && !didRequestInputMonitoring {
+                didRequestInputMonitoring = true
+                CGRequestListenEventAccess()
+            }
+
+            if axGranted && imGranted {
                 timer.invalidate()
                 completion(true)
-            } else if attempts > 60 {
+            } else if attempts > 120 {
                 timer.invalidate()
                 completion(false)
             }

--- a/Sources/HRM/App/AppState.swift
+++ b/Sources/HRM/App/AppState.swift
@@ -5,12 +5,19 @@ import Combine
 final class AppState: ObservableObject {
     @Published var configuration: Configuration
     @Published var isAccessibilityGranted = false
+    @Published var isInputMonitoringGranted = false
+    @Published var eventTapFailed = false
+    @Published var eventTapDegraded = false
     @Published var availableUpdate: String?
+
+    let keyboardMonitor = KeyboardMonitor()
 
     private let store = ConfigurationStore()
     private var engine: TapHoldEngine
     private var eventTapManager: EventTapManager?
     private var hasLaunched = false
+    private var monitorCancellable: AnyCancellable?
+    private var permissionTimer: Timer?
 
     var isEnabled: Bool {
         get { configuration.enabled }
@@ -24,6 +31,11 @@ final class AppState: ObservableObject {
         let config = store.load()
         self.configuration = config
         self.engine = TapHoldEngine(config: config)
+
+        // Forward keyboard monitor changes to trigger UI updates
+        monitorCancellable = keyboardMonitor.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
 
         // Defer startup to after SwiftUI scene is ready
         Task { @MainActor [weak self] in
@@ -40,18 +52,29 @@ final class AppState: ObservableObject {
             self?.availableUpdate = update
         }
 
-        checkAccessibility()
-        if isAccessibilityGranted {
+        checkPermissions()
+        startPermissionPolling()
+        if AccessibilityManager.hasAllPermissions {
             startEventTap()
         } else {
-            requestAccessibility()
+            requestPermissions()
         }
     }
 
     func startEventTap() {
         guard eventTapManager == nil else { return }
         let manager = EventTapManager(engine: engine)
+        manager.keyboardMonitor = keyboardMonitor
+        manager.setSelectedKeyboard(configuration.selectedKeyboard)
+        manager.setRemapCapsLockToBackspace(configuration.remapCapsLockToBackspace)
+        manager.onEventTapFailed = { [weak self] in
+            self?.eventTapFailed = true
+        }
+        manager.onEventTapDegraded = { [weak self] in
+            self?.eventTapDegraded = true
+        }
         self.eventTapManager = manager
+        eventTapFailed = false
         if configuration.enabled {
             manager.start()
         }
@@ -65,6 +88,8 @@ final class AppState: ObservableObject {
     func saveAndApply() {
         try? store.save(configuration)
         engine.updateConfig(configuration)
+        eventTapManager?.setSelectedKeyboard(configuration.selectedKeyboard)
+        eventTapManager?.setRemapCapsLockToBackspace(configuration.remapCapsLockToBackspace)
 
         if configuration.enabled {
             if eventTapManager?.isRunning == false {
@@ -75,14 +100,31 @@ final class AppState: ObservableObject {
         }
     }
 
-    func checkAccessibility() {
+    func checkPermissions() {
         isAccessibilityGranted = AccessibilityManager.isTrusted
+        isInputMonitoringGranted = AccessibilityManager.isInputMonitoringGranted
     }
 
-    func requestAccessibility() {
-        AccessibilityManager.ensureAccessibility { [weak self] granted in
+    /// Periodically re-check permissions so the UI stays up to date
+    func startPermissionPolling() {
+        permissionTimer?.invalidate()
+        permissionTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                self?.isAccessibilityGranted = granted
+                self?.checkPermissions()
+            }
+        }
+    }
+
+    func stopPermissionPolling() {
+        permissionTimer?.invalidate()
+        permissionTimer = nil
+    }
+
+    func requestPermissions() {
+        AccessibilityManager.ensureAllPermissions { [weak self] granted in
+            Task { @MainActor in
+                self?.isAccessibilityGranted = AccessibilityManager.isTrusted
+                self?.isInputMonitoringGranted = AccessibilityManager.isInputMonitoringGranted
                 if granted {
                     self?.startEventTap()
                 }

--- a/Sources/HRM/App/KeyboardMonitor.swift
+++ b/Sources/HRM/App/KeyboardMonitor.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Discovers keyboards by observing keyboardEventKeyboardType values from CGEvent.
+/// No extra permissions required beyond the existing Accessibility permission.
+final class KeyboardMonitor: ObservableObject {
+    @Published var discoveredKeyboards: [KeyboardDevice] = []
+
+    private let lock = NSLock()
+    private var observedTypes: Set<Int> = []
+
+    /// Called from the event tap thread when a key event is processed.
+    func recordKeyboardType(_ type: Int) {
+        lock.lock()
+        let isNew = observedTypes.insert(type).inserted
+        lock.unlock()
+
+        if isNew {
+            DispatchQueue.main.async { [weak self] in
+                self?.rebuildList()
+            }
+        }
+    }
+
+    private func rebuildList() {
+        lock.lock()
+        let types = observedTypes
+        lock.unlock()
+
+        discoveredKeyboards = types
+            .map { KeyboardDevice(keyboardType: $0) }
+            .sorted { $0.name < $1.name }
+    }
+}

--- a/Sources/HRM/EventTap/EventTapCallback.swift
+++ b/Sources/HRM/EventTap/EventTapCallback.swift
@@ -37,5 +37,10 @@ func eventTapCallback(
         return Unmanaged.passUnretained(event)
     }
 
+    // Skip events from keyboards that don't match the selected filter
+    if manager.shouldFilterEvent(event) {
+        return Unmanaged.passUnretained(event)
+    }
+
     return manager.processEvent(proxy: proxy, type: type, event: event)
 }

--- a/Sources/HRM/EventTap/EventTapManager.swift
+++ b/Sources/HRM/EventTap/EventTapManager.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import CoreGraphics
 import Foundation
 
@@ -8,19 +9,75 @@ final class EventTapManager: TapHoldEngineDelegate {
     private var engine: TapHoldEngine
     private let synthesizer = EventSynthesizer()
     private var currentModifierFlags: CGEventFlags = []
+    /// Monitor that discovers keyboards from the event stream.
+    weak var keyboardMonitor: KeyboardMonitor?
     /// Key codes currently being suppressed by the engine (undecided/hold).
     /// Used by the callback to skip auto-repeat events without entering the engine.
     private(set) var suppressedKeyCodes: Set<UInt16> = []
 
     private(set) var isRunning = false
+    /// Called on the main queue when the event tap fails to create or is degraded.
+    var onEventTapFailed: (() -> Void)?
+    /// Called on the main queue when the event tap needs re-authorization.
+    var onEventTapDegraded: (() -> Void)?
+
+    /// Tracks whether we've received any keyDown events (not just flagsChanged).
+    /// If we see flagsChanged but no keyDown within a few seconds, the tap is degraded.
+    private var hasReceivedKeyDown = false
+    private var hasReceivedFlagsChanged = false
+
+    /// Keyboard type to filter for, or -1 for all keyboards.
+    private var _selectedKeyboardType: Int = -1
+
+    /// Whether Caps Lock → Backspace remap is active.
+    private var _remapCapsLockToBackspace: Bool = false
+
+    /// Tracks whether Caps Lock (remapped to F18) is physically held for auto-repeat.
+    private var capsLockDown = false
+    private var capsLockRepeatTimer: DispatchSourceTimer?
+
+    // Caps Lock is remapped to F18 via hidutil at the HID level.
+    // F18 CGEvent keycode = 79 (0x4F). This means our event tap sees
+    // regular keyDown/keyUp for F18 — no toggle, no LED, no caps state.
+    private static let f18KeyCode: UInt16 = 0x4F
+    private static let backspaceKeyCode: UInt16 = 0x33
 
     init(engine: TapHoldEngine) {
         self.engine = engine
         engine.delegate = self
     }
 
+    func setSelectedKeyboard(_ keyboard: KeyboardDevice?) {
+        _selectedKeyboardType = keyboard?.keyboardType ?? -1
+    }
+
+    func setRemapCapsLockToBackspace(_ enabled: Bool) {
+        let wasEnabled = _remapCapsLockToBackspace
+        _remapCapsLockToBackspace = enabled
+        if enabled && !wasEnabled {
+            Self.applyCapsLockHidutilMapping()
+        } else if !enabled && wasEnabled {
+            stopCapsLockRepeat()
+            capsLockDown = false
+            Self.removeCapsLockHidutilMapping()
+        }
+    }
+
+    func shouldFilterEvent(_ event: CGEvent) -> Bool {
+        let keyboardType = Int(event.getIntegerValueField(.keyboardEventKeyboardType))
+        keyboardMonitor?.recordKeyboardType(keyboardType)
+        let selected = _selectedKeyboardType
+        guard selected >= 0 else { return false }
+        return keyboardType != selected
+    }
+
     func start() {
         guard !isRunning else { return }
+
+        // Apply hidutil mapping if caps lock remap is enabled
+        if _remapCapsLockToBackspace {
+            Self.applyCapsLockHidutilMapping()
+        }
 
         tapThread = Thread { [weak self] in
             self?.runEventTapLoop()
@@ -33,6 +90,11 @@ final class EventTapManager: TapHoldEngineDelegate {
     func stop() {
         guard isRunning else { return }
         isRunning = false
+        stopCapsLockRepeat()
+
+        if _remapCapsLockToBackspace {
+            Self.removeCapsLockHidutilMapping()
+        }
 
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
@@ -69,11 +131,33 @@ final class EventTapManager: TapHoldEngineDelegate {
         let result: TapHoldEngine.EventResult
 
         if type == .keyDown {
+            hasReceivedKeyDown = true
+
+            // F18 (remapped Caps Lock) → Backspace
+            if keyCode == Self.f18KeyCode && _remapCapsLockToBackspace {
+                if !capsLockDown {
+                    capsLockDown = true
+                    synthesizer.postKeyDown(keyCode: Self.backspaceKeyCode, flags: currentModifierFlags)
+                    startCapsLockRepeat()
+                }
+                return nil
+            }
+
             result = engine.handleKeyDown(keyCode: keyCode, event: event, timestamp: timestamp)
         } else if type == .keyUp {
+            // F18 (remapped Caps Lock) → Backspace release
+            if keyCode == Self.f18KeyCode && _remapCapsLockToBackspace {
+                capsLockDown = false
+                stopCapsLockRepeat()
+                synthesizer.postKeyUp(keyCode: Self.backspaceKeyCode, flags: currentModifierFlags)
+                return nil
+            }
+
             result = engine.handleKeyUp(keyCode: keyCode, event: event, timestamp: timestamp)
+        } else if type == .flagsChanged {
+            hasReceivedFlagsChanged = true
+            return Unmanaged.passUnretained(event)
         } else {
-            // flagsChanged — pass through
             return Unmanaged.passUnretained(event)
         }
 
@@ -123,12 +207,66 @@ final class EventTapManager: TapHoldEngineDelegate {
 
     func engineShouldFlushBufferedEvents(_ events: [BufferedEvent]) {
         for buffered in events {
-            // Apply current modifier flags to buffered events
             if !currentModifierFlags.isEmpty {
                 buffered.event.flags = buffered.event.flags.union(currentModifierFlags)
             }
             synthesizer.postEvent(buffered.event)
         }
+    }
+
+    // MARK: - Caps Lock Repeat
+
+    private func startCapsLockRepeat() {
+        stopCapsLockRepeat()
+        let initialTicks = UserDefaults.standard.integer(forKey: "InitialKeyRepeat")
+        let repeatTicks = UserDefaults.standard.integer(forKey: "KeyRepeat")
+        let initialDelay = Double(initialTicks > 0 ? initialTicks : 25) * 0.015
+        let repeatInterval = Double(repeatTicks > 0 ? repeatTicks : 6) * 0.015
+
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .userInteractive))
+        timer.schedule(deadline: .now() + initialDelay, repeating: repeatInterval)
+        timer.setEventHandler { [weak self] in
+            guard let self, self.capsLockDown else { return }
+            self.synthesizer.postKeyDown(keyCode: Self.backspaceKeyCode, flags: self.currentModifierFlags)
+        }
+        timer.resume()
+        capsLockRepeatTimer = timer
+    }
+
+    private func stopCapsLockRepeat() {
+        capsLockRepeatTimer?.cancel()
+        capsLockRepeatTimer = nil
+    }
+
+    // MARK: - hidutil Caps Lock Mapping
+
+    /// Remap Caps Lock → F18 at the HID level using hidutil.
+    /// This prevents macOS from toggling Caps Lock state/LED entirely.
+    private static func applyCapsLockHidutilMapping() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/hidutil")
+        process.arguments = [
+            "property", "--set",
+            """
+            {"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000039,"HIDKeyboardModifierMappingDst":0x70000006D}]}
+            """,
+        ]
+        try? process.run()
+        process.waitUntilExit()
+    }
+
+    /// Remove the Caps Lock → F18 mapping, restoring default behavior.
+    private static func removeCapsLockHidutilMapping() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/hidutil")
+        process.arguments = [
+            "property", "--set",
+            """
+            {"UserKeyMapping":[]}
+            """,
+        ]
+        try? process.run()
+        process.waitUntilExit()
     }
 
     // MARK: - Private
@@ -148,7 +286,9 @@ final class EventTapManager: TapHoldEngineDelegate {
             callback: eventTapCallback,
             userInfo: selfPtr
         ) else {
-            print("HRM: Failed to create event tap. Check Accessibility permissions.")
+            DispatchQueue.main.async { [weak self] in
+                self?.onEventTapFailed?()
+            }
             return
         }
 
@@ -162,6 +302,18 @@ final class EventTapManager: TapHoldEngineDelegate {
         CGEvent.tapEnable(tap: tap, enable: true)
 
         isRunning = true
+
+        // Watchdog: after 5 seconds, check if we're receiving keyDown events.
+        // If we only see flagsChanged but no keyDown, the tap is degraded (stale permissions).
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
+            guard let self, self.isRunning else { return }
+            if self.hasReceivedFlagsChanged && !self.hasReceivedKeyDown {
+                DispatchQueue.main.async {
+                    self.onEventTapDegraded?()
+                }
+            }
+        }
+
         CFRunLoopRun()
     }
 }

--- a/Sources/HRM/Model/Configuration.swift
+++ b/Sources/HRM/Model/Configuration.swift
@@ -5,6 +5,8 @@ struct Configuration: Codable, Equatable {
     var bilateralFiltering: Bool
     var holdTriggerOnRelease: Bool
     var keyBindings: [KeyBinding]
+    var selectedKeyboard: KeyboardDevice?
+    var remapCapsLockToBackspace: Bool
 
     func effectiveQuickTapTerm(for binding: KeyBinding) -> Int {
         binding.quickTapTermMs ?? quickTapTermMs

--- a/Sources/HRM/Model/KeyboardDevice.swift
+++ b/Sources/HRM/Model/KeyboardDevice.swift
@@ -1,0 +1,17 @@
+struct KeyboardDevice: Codable, Equatable, Hashable, Identifiable {
+    let keyboardType: Int
+
+    var id: Int { keyboardType }
+
+    var name: String {
+        switch keyboardType {
+        case 59: return "Built-in Keyboard (ANSI)"
+        case 60: return "Built-in Keyboard (ISO)"
+        case 61: return "Built-in Keyboard (JIS)"
+        case 40: return "Apple External (ANSI)"
+        case 41: return "Apple External (ISO)"
+        case 42: return "Apple External (JIS)"
+        default: return "Keyboard (Type \(keyboardType))"
+        }
+    }
+}

--- a/Sources/HRM/Persistence/DefaultConfiguration.swift
+++ b/Sources/HRM/Persistence/DefaultConfiguration.swift
@@ -6,7 +6,9 @@ enum DefaultConfiguration {
             requirePriorIdleMs: 150,
             bilateralFiltering: true,
             holdTriggerOnRelease: false,
-            keyBindings: defaultKeyBindings
+            keyBindings: defaultKeyBindings,
+            selectedKeyboard: nil,
+            remapCapsLockToBackspace: false
         )
     }
 

--- a/Sources/HRM/UI/MenuBarPanelView.swift
+++ b/Sources/HRM/UI/MenuBarPanelView.swift
@@ -48,15 +48,80 @@ struct MenuBarPanelView: View {
                 .fixedSize()
             }
 
-            if !appState.isAccessibilityGranted {
-                Button("Grant Accessibility Permission") {
-                    appState.requestAccessibility()
+            permissionStatus
+
+            if appState.eventTapFailed {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("Event tap failed to start", systemImage: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    Text("Remove HRM from Accessibility and Input Monitoring in System Settings, restart the app, and re-grant permissions.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        Button("Open Privacy Settings") { openPrivacySettings() }
+                        Button("Retry") {
+                            appState.stopEventTap()
+                            appState.startEventTap()
+                        }
+                    }
+                    .controlSize(.small)
                 }
-                .controlSize(.small)
+            }
+
+            if appState.eventTapDegraded {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("Keyboard events not received — permissions may be stale", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    Text("Remove HRM from both Accessibility and Input Monitoring, restart the app, and re-grant permissions.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("Open Privacy Settings") { openPrivacySettings() }
+                        .controlSize(.small)
+                }
             }
         }
         .padding(.horizontal)
         .padding(.vertical, 10)
+    }
+
+    // MARK: - Permission Status
+
+    @ViewBuilder
+    private var permissionStatus: some View {
+        let axOK = appState.isAccessibilityGranted
+        let imOK = appState.isInputMonitoringGranted
+
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: axOK ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(axOK ? .green : .red)
+                Text("Accessibility")
+                    .font(.caption)
+                Spacer()
+                Image(systemName: imOK ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(imOK ? .green : .red)
+                Text("Input Monitoring")
+                    .font(.caption)
+            }
+
+            if !axOK || !imOK {
+                HStack {
+                    Button("Grant Permissions") {
+                        appState.requestPermissions()
+                    }
+                    Button("Open Privacy Settings") { openPrivacySettings() }
+                }
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private func openPrivacySettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     // MARK: - Update Banner
@@ -120,6 +185,8 @@ struct MenuBarPanelView: View {
 
             settingToggle("Launch at Login", isOn: launchAtLoginBinding)
 
+            settingToggle("Caps Lock → Backspace", isOn: capsLockRemapBinding)
+
             settingToggle("Bilateral Filtering", isOn: bilateralFilteringBinding)
 
             HStack {
@@ -138,6 +205,21 @@ struct MenuBarPanelView: View {
             .disabled(!appState.configuration.bilateralFiltering)
             msStepper("Quick Tap Term", value: quickTapTermBinding)
             msStepper("Require Prior Idle", value: requirePriorIdleBinding)
+
+            HStack {
+                Text("Keyboard")
+                    .font(.body)
+                Spacer()
+                Picker("", selection: selectedKeyboardBinding) {
+                    Text("All Keyboards").tag(Int?.none)
+                    ForEach(appState.keyboardMonitor.discoveredKeyboards) { keyboard in
+                        Text(keyboard.name).tag(Int?.some(keyboard.keyboardType))
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: 200)
+                .labelsHidden()
+            }
         }
     }
 
@@ -203,6 +285,16 @@ struct MenuBarPanelView: View {
         )
     }
 
+    private var capsLockRemapBinding: Binding<Bool> {
+        Binding(
+            get: { appState.configuration.remapCapsLockToBackspace },
+            set: {
+                appState.configuration.remapCapsLockToBackspace = $0
+                appState.saveAndApply()
+            }
+        )
+    }
+
     private var bilateralFilteringBinding: Binding<Bool> {
         Binding(
             get: { appState.configuration.bilateralFiltering },
@@ -238,6 +330,22 @@ struct MenuBarPanelView: View {
             get: { appState.configuration.requirePriorIdleMs },
             set: {
                 appState.configuration.requirePriorIdleMs = $0
+                appState.saveAndApply()
+            }
+        )
+    }
+
+    private var selectedKeyboardBinding: Binding<Int?> {
+        Binding(
+            get: { appState.configuration.selectedKeyboard?.keyboardType },
+            set: { newType in
+                if let type = newType,
+                   let device = appState.keyboardMonitor.discoveredKeyboards.first(where: { $0.keyboardType == type })
+                {
+                    appState.configuration.selectedKeyboard = device
+                } else {
+                    appState.configuration.selectedKeyboard = nil
+                }
                 appState.saveAndApply()
             }
         )


### PR DESCRIPTION
## Summary

- **Keyboard selection**: Discover connected keyboards from the CGEvent stream and allow filtering HRM to a specific keyboard via a picker in settings. Defaults to "All Keyboards".
- **Caps Lock → Backspace remap**: Uses `hidutil` to remap Caps Lock → F18 at the HID level (no LED toggle, no caps state change), then intercepts F18 in the event tap and synthesizes Backspace with system key repeat support.
- **Permission detection**: Check both Accessibility and Input Monitoring permissions, show live status indicators (green/red), detect degraded event tap (stale permissions after re-signing), and display actionable error banners.

## Details

### Keyboard Selection
- New `KeyboardDevice` model identifies keyboards by `keyboardEventKeyboardType`
- `KeyboardMonitor` discovers keyboards as keys are pressed (no extra permissions needed)
- Picker in settings to select a specific keyboard or "All Keyboards"

### Caps Lock → Backspace
- `hidutil` remaps Caps Lock → F18 at the HID level, bypassing macOS Caps Lock handling entirely
- Event tap receives F18 as regular keyDown/keyUp — proper hold detection and auto-repeat using system key repeat settings
- Mapping is applied when the toggle is enabled and removed when disabled or app stops

### Permission Detection
- `AccessibilityManager` now checks both `AXIsProcessTrusted()` and `CGPreflightListenEventAccess()`
- UI shows live permission status with periodic polling
- Watchdog detects degraded event tap (receives flagsChanged but no keyDown) and shows guidance
- "Open Privacy Settings" button for quick access

## Test plan
- [ ] Verify home row mods still work correctly
- [ ] Enable "Caps Lock → Backspace" — tap should delete one char, hold should auto-repeat
- [ ] Disable the toggle — Caps Lock should return to normal behavior
- [ ] Test keyboard picker with multiple keyboards connected
- [ ] Remove app from Accessibility — verify red indicator appears
- [ ] Remove app from Input Monitoring — verify red indicator appears
- [ ] Re-grant both permissions — verify green indicators and functionality restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)