### PR TITLE
Fix collapsed menu bar panel on macOS 26

### DIFF
--- a/Sources/HRM/UI/MenuBarPanelView.swift
+++ b/Sources/HRM/UI/MenuBarPanelView.swift
@@ -14,7 +14,7 @@ struct MenuBarPanelView: View {
                     updateBanner(version: version)
                 }
                 Divider()
-                scrollContent
+                content
                 Divider()
                 footer
             }
@@ -30,6 +30,7 @@ struct MenuBarPanelView: View {
             }
         }
         .frame(width: 400)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: - Header
@@ -80,17 +81,15 @@ struct MenuBarPanelView: View {
         .background(.quaternary)
     }
 
-    // MARK: - Scroll Content
+    // MARK: - Content
 
-    private var scrollContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                keyboardSection
-                Divider()
-                settingsSection
-            }
-            .padding()
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            keyboardSection
+            Divider()
+            settingsSection
         }
+        .padding()
     }
 
     // MARK: - Keyboard Section


### PR DESCRIPTION
## Summary

On macOS 26, `MenuBarExtra(.window)` no longer grows to fit a `ScrollView` that has no intrinsic height. The panel collapses to a sliver between header and footer — only the Enabled toggle, Reset to Defaults, and Quit remain visible; the key grid and Settings section are clipped. Matches the screenshot in #5.

## Fix

The panel's content already fits without scrolling, so the `ScrollView` isn't needed. Replace it with the plain `VStack` and add `.fixedSize(horizontal: false, vertical: true)` to the root so the panel sizes naturally — no hard-coded height, adapts if rows are added/removed.

## Test plan

- [x] Build release on macOS 26.4, launch from `/Applications`
- [x] Menu bar panel now shows Key Bindings grid + Settings section + footer
- [x] Panel height adjusts when update banner / "Grant Accessibility" button appear
- [ ] Sanity check on macOS 14/15 (no regression expected — removing `ScrollView` just lets the VStack size naturally)

Closes #5