### PR TITLE
Add keyboard device selector

### DIFF
--- a/Sources/HRM/App/AppState.swift
+++ b/Sources/HRM/App/AppState.swift
@@ -8,11 +8,13 @@ final class AppState: ObservableObject {
     @Published var availableUpdate: String?
     @Published private(set) var keyboardLayoutVersion = 0
 
+    let keyboardMonitor = KeyboardMonitor()
     private let store = ConfigurationStore()
     private var engine: TapHoldEngine
     private var eventTapManager: EventTapManager?
     private var hasLaunched = false
     private var inputSourceObserver: Any?
+    private var monitorCancellable: AnyCancellable?
 
     var isEnabled: Bool {
         get { configuration.enabled }
@@ -26,6 +28,10 @@ final class AppState: ObservableObject {
         let config = store.load()
         self.configuration = config
         self.engine = TapHoldEngine(config: config)
+
+        monitorCancellable = keyboardMonitor.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
 
         // Defer startup to after SwiftUI scene is ready
         Task { @MainActor [weak self] in
@@ -63,6 +69,8 @@ final class AppState: ObservableObject {
     func startEventTap() {
         guard eventTapManager == nil else { return }
         let manager = EventTapManager(engine: engine)
+        manager.keyboardMonitor = keyboardMonitor
+        manager.setSelectedKeyboard(configuration.selectedKeyboard)
         self.eventTapManager = manager
         if configuration.enabled {
             manager.start()
@@ -77,6 +85,7 @@ final class AppState: ObservableObject {
     func saveAndApply() {
         try? store.save(configuration)
         engine.updateConfig(configuration)
+        eventTapManager?.setSelectedKeyboard(configuration.selectedKeyboard)
 
         if configuration.enabled {
             if eventTapManager?.isRunning == false {

--- a/Sources/HRM/App/KeyboardMonitor.swift
+++ b/Sources/HRM/App/KeyboardMonitor.swift
@@ -1,0 +1,17 @@
+import Combine
+import Foundation
+
+@MainActor
+final class KeyboardMonitor: ObservableObject {
+    @Published private(set) var discoveredKeyboards: [KeyboardDevice] = []
+    private var seenTypes: Set<Int> = []
+
+    nonisolated func recordKeyboardType(_ type: Int) {
+        Task { @MainActor in
+            guard !seenTypes.contains(type) else { return }
+            seenTypes.insert(type)
+            let name = "Keyboard (type \(type))"
+            discoveredKeyboards.append(KeyboardDevice(keyboardType: type, name: name))
+        }
+    }
+}

--- a/Sources/HRM/EventTap/EventTapCallback.swift
+++ b/Sources/HRM/EventTap/EventTapCallback.swift
@@ -37,5 +37,10 @@ func eventTapCallback(
         return Unmanaged.passUnretained(event)
     }
 
+    // Skip events from keyboards that don't match the selected filter
+    if manager.shouldFilterEvent(event) {
+        return Unmanaged.passUnretained(event)
+    }
+
     return manager.processEvent(proxy: proxy, type: type, event: event)
 }

--- a/Sources/HRM/EventTap/EventTapManager.swift
+++ b/Sources/HRM/EventTap/EventTapManager.swift
@@ -13,6 +13,10 @@ final class EventTapManager: TapHoldEngineDelegate {
     private(set) var suppressedKeyCodes: Set<UInt16> = []
 
     private(set) var isRunning = false
+    /// Monitor that discovers keyboards from the event stream.
+    weak var keyboardMonitor: KeyboardMonitor?
+    /// Keyboard type to filter for, or -1 for all keyboards.
+    private var _selectedKeyboardType: Int = -1
 
     init(engine: TapHoldEngine) {
         self.engine = engine
@@ -54,6 +58,18 @@ final class EventTapManager: TapHoldEngineDelegate {
     func updateEngine(_ engine: TapHoldEngine) {
         self.engine = engine
         engine.delegate = self
+    }
+
+    func setSelectedKeyboard(_ keyboard: KeyboardDevice?) {
+        _selectedKeyboardType = keyboard?.keyboardType ?? -1
+    }
+
+    func shouldFilterEvent(_ event: CGEvent) -> Bool {
+        let keyboardType = Int(event.getIntegerValueField(.keyboardEventKeyboardType))
+        keyboardMonitor?.recordKeyboardType(keyboardType)
+        let selected = _selectedKeyboardType
+        guard selected >= 0 else { return false }
+        return keyboardType != selected
     }
 
     // MARK: - Event Processing (called from C callback)

--- a/Sources/HRM/Model/Configuration.swift
+++ b/Sources/HRM/Model/Configuration.swift
@@ -5,6 +5,7 @@ struct Configuration: Codable, Equatable {
     var bilateralFiltering: Bool
     var holdTriggerOnRelease: Bool
     var keyBindings: [KeyBinding]
+    var selectedKeyboard: KeyboardDevice?
 
     func effectiveQuickTapTerm(for binding: KeyBinding) -> Int {
         binding.quickTapTermMs ?? quickTapTermMs

--- a/Sources/HRM/Model/KeyboardDevice.swift
+++ b/Sources/HRM/Model/KeyboardDevice.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct KeyboardDevice: Codable, Equatable, Identifiable {
+    let keyboardType: Int
+    let name: String
+
+    var id: Int { keyboardType }
+}

--- a/Sources/HRM/Persistence/DefaultConfiguration.swift
+++ b/Sources/HRM/Persistence/DefaultConfiguration.swift
@@ -6,7 +6,8 @@ enum DefaultConfiguration {
             requirePriorIdleMs: 150,
             bilateralFiltering: true,
             holdTriggerOnRelease: true,
-            keyBindings: defaultKeyBindings
+            keyBindings: defaultKeyBindings,
+            selectedKeyboard: nil
         )
     }
 

--- a/Sources/HRM/UI/MenuBarPanelView.swift
+++ b/Sources/HRM/UI/MenuBarPanelView.swift
@@ -143,6 +143,20 @@ struct MenuBarPanelView: View {
             .disabled(!appState.configuration.bilateralFiltering)
             msStepper("Quick Tap Term", value: quickTapTermBinding)
             msStepper("Require Prior Idle", value: requirePriorIdleBinding)
+            HStack {
+                Text("Keyboard")
+                    .font(.body)
+                Spacer()
+                Picker("", selection: selectedKeyboardBinding) {
+                    Text("All Keyboards").tag(Int?.none)
+                    ForEach(appState.keyboardMonitor.discoveredKeyboards) { keyboard in
+                        Text(keyboard.name).tag(Int?.some(keyboard.keyboardType))
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: 200)
+                .labelsHidden()
+            }
         }
     }
 
@@ -233,6 +247,22 @@ struct MenuBarPanelView: View {
             get: { appState.configuration.quickTapTermMs },
             set: {
                 appState.configuration.quickTapTermMs = $0
+                appState.saveAndApply()
+            }
+        )
+    }
+
+    private var selectedKeyboardBinding: Binding<Int?> {
+        Binding(
+            get: { appState.configuration.selectedKeyboard?.keyboardType },
+            set: { newType in
+                if let type = newType,
+                   let device = appState.keyboardMonitor.discoveredKeyboards.first(where: { $0.keyboardType == type })
+                {
+                    appState.configuration.selectedKeyboard = device
+                } else {
+                    appState.configuration.selectedKeyboard = nil
+                }
                 appState.saveAndApply()
             }
         )


### PR DESCRIPTION
## Summary
- Adds ability to filter which keyboard HRM applies to, so external keyboards or different devices don't interfere
- Keyboards are auto-discovered from the event stream and appear in a dropdown in Settings
- Defaults to "All Keyboards"

## How it works
- `KeyboardMonitor` discovers keyboard types from incoming CGEvents
- `EventTapManager.shouldFilterEvent()` skips events from non-selected keyboards
- Users pick a keyboard in the Settings section of the menu bar panel

## Test plan
- [ ] Enable HRM, verify all keyboards work by default
- [ ] If multiple keyboards are available, select one and verify only that keyboard's events are processed
- [ ] Switch back to "All Keyboards" and verify everything works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)